### PR TITLE
36 one file per annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,37 @@
 This is a plugin for [Obsidian](https://obsidian.md). It extracts all types of annotations (highlight, underline, squiggle, note, free text, etc.) from PDF files inside and outside the Obsidian Vault.
 It can be used on single PDF files (see [`Extract PDF Annotations on single file` and `Extract PDF Annotations from single file from path in clipboard`](#commands)) or even on a whole directory containing PDFs (see [`Extract PDF Annotations`](#commands)) for batch extraction.
 
-## Usage
+## Features
+* `Extract PDF Annotations` Works when editing a markdown note. Searches all PDF files in current Folder for annotations, and inserts them at the current position of the open note. 
+* `Extract PDF Annotations on single file` Works while displaying a PDF file inside the Obsidian PDF-Viewer. Extracts annotations from this file and writes them to the note `Annotations for <filename>`
+* `Extract PDF Annotations from single file from path in clipboard` Works when editing a markdown note. Looks for a file path of a PDF in clipboard, extracts annotations from it and inserts them at the current position of the open note. This command can be used for external PDF files, which are not part of the Obsidian Vault. Helpful, if you do not want to copy your PDFs inside your vault.
 
-This Plugin visits all PDF files in a given directory and extracts comments and highlights from the PDF files. It treats the first line of every comment as *Topic* for grouping the comments. 
+## Plugin Settings
+* Desired annotations
+	* Select your desired annotation types that should be extracted from the PDF, if it includes other types that you don't need
+* Styling settings
+	* Template settings for different types of notes: notes from internal or external PDFs and highlights from internal or external PDFs. The distinction between internal and external exists, if one wants to use different links (internal `[[]]` links vs. external `file://` links). The following template variables are available and can be used by following the [Handlebars]('https://handlebarsjs.com/guide/expressions.html') syntax: 
+		- {{highlightedText}}: 'Highlighted text from PDF',
+		- {{folder}}: 'Folder of PDF file',
+		- {{file}}: 'Binary content of file',
+		- {{filepath}}: 'Path of PDF file',
+		- {{pageNumber}}: 'Page number of annotation with reference to PDF pages',
+		- {{author}}: 'Author of annotation',
+		- {{body}}: 'Body of annotation'
+	* Structure settings
+		* Use structuring headlines or not, if you only want to display annotations in the specified template
+		* Use the first line of the comment as 'Topic' (and sort accordingly), or not
+		* Use folder name or PDF-Filename for sorting
+* Settings for `Extract PDF Annotations on single file`
+	* Specify the export path for the command
+	* Specify the export name for the command
+	* Create one note per annotation
+	* Specify the export name for each note per annotation
+
+## How it works
+`Extract PDF Annotations`
+
+This command visits all PDF files in the current directory and extracts comments and highlights from the PDF files into the open note. It treats the first line of every comment as *Topic* for grouping the comments. 
 
 Assume we have in a folder in our Vault containing PDF files, e.g: 
 
@@ -19,28 +47,7 @@ In the editor (e.g. \_Extract) we run the plugin's command  `Extract PDF Annotat
 
 ![extracted_annotations](https://github.com/munach/obsidian-pdf-annotations/blob/master/img/extracted_annotations.jpg?raw=true)
 
-As such, you can relate comments for your topics (here 'Hello World') from several PDF files. 
-
-### Commands
-* `Extract PDF Annotations` Works when editing a markdown note. Searches all PDF files in current Folder for annotations, and inserts them at the current position of the open note. 
-* `Extract PDF Annotations on single file` Works while displaying a PDF file inside the Obsidian PDF-Viewer. Extracts annotations from this file and writes them to the note `Annotations for <filename>`
-* `Extract PDF Annotations from single file from path in clipboard` Works when editing a markdown note. Looks for a file path of a PDF in clipboard, extracts annotations from it and inserts them at the current position of the open note. This command can be used for external PDF files, which are not part of the Obsidian Vault. Helpful, if you do not want to copy your PDFs inside your vault.
-
-### Plugin Settings: 
-
-* Use structuring headlines or not, if you only want to display annotations in the specified template
-* Use the first line of the comment as 'Topic' (and sort accordingly), or not
-* Use folder name or PDF-Filename for sorting
-* Specify the export path for the command `Extract PDF Annotations on single file`
-* Select your desired annotation types that should be extracted from the PDF, if it includes other types that you don't need
-* Template settings for different types of notes: notes from internal or external PDFs and highlights from internal or external PDFs. The distinction between internal and external exists, if one wants to use different links (internal `[[]]` links vs. external `file://` links). The following template variables are available and can be used by following the [Handlebars]('https://handlebarsjs.com/guide/expressions.html') syntax: 
-    - {{highlightedText}}: 'Highlighted text from PDF',
-	- {{folder}}: 'Folder of PDF file',
-	- {{file}}: 'Binary content of file',
-	- {{filepath}}: 'Path of PDF file',
-	- {{pageNumber}}: 'Page number of annotation with reference to PDF pages',
-	- {{author}}: 'Author of annotation',
-	- {{body}}: 'Body of annotation'
+As such, you can relate comments for your topics (here 'Hello World') from several PDF files.
 
 ## Versions
 1.7.0 add settings for dynamic export path (next to PDF) and export name

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ In the editor (e.g. \_Extract) we run the plugin's command  `Extract PDF Annotat
 As such, you can relate comments for your topics (here 'Hello World') from several PDF files.
 
 ## Versions
+1.8.0 add option to export each extracted annotation to a separate note
+
 1.7.0 add settings for dynamic export path (next to PDF) and export name
 
 1.6.0 fix bug after pdfjs api change

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,0 +1,136 @@
+import {
+	compile as compileTemplate,
+	TemplateDelegate as Template,
+} from "handlebars";
+import {
+	ANNOTS_TREATED_AS_HIGHLIGHTS,
+	PDFAnnotationPluginSetting,
+} from "./settings";
+
+export class PDFAnnotationPluginFormatter {
+	private settings: PDFAnnotationPluginSetting;
+
+	// Template compilation options
+	private templateSettings = {
+		noEscape: true,
+	};
+
+	constructor(settings: PDFAnnotationPluginSetting) {
+		this.settings = settings;
+	}
+
+	format(grandtotal, isExternalFile) {
+		// now iterate over the annotations printing topics, then folder, then comments...
+		let text = "";
+		let topic = "";
+		let currentFolder = "";
+		// console.log("all annots", grandtotal)
+		grandtotal.forEach((anno) => {
+			// print main Title when Topic changes (and settings allow)
+			if (this.settings.useStructuringHeadlines) {
+				if (this.settings.sortByTopic) {
+					if (topic != anno.topic) {
+						topic = anno.topic;
+						currentFolder = "";
+						text += `# ${topic}\n`;
+					}
+				}
+
+				if (this.settings.useFolderNames) {
+					if (currentFolder != anno.folder) {
+						currentFolder = anno.folder;
+						text += `## ${currentFolder}\n`;
+					}
+				} else {
+					if (currentFolder != anno.file.name) {
+						currentFolder = anno.file.name;
+						text += `## ${currentFolder}\n`;
+					}
+				}
+			}
+
+			if (ANNOTS_TREATED_AS_HIGHLIGHTS.includes(anno.subtype)) {
+				if (isExternalFile) {
+					text += this.getContentForHighlightFromExternalPDF(anno);
+				} else {
+					text += this.getContentForHighlightFromInternalPDF(anno);
+				}
+			} else {
+				if (isExternalFile) {
+					text += this.getContentForNoteFromExternalPDF(anno);
+				} else {
+					text += this.getContentForNoteFromInternalPDF(anno);
+				}
+			}
+		});
+
+		if (grandtotal.length == 0) return "*No Annotations*";
+		else return text;
+	}
+
+	get noteFromExternalPDFsTemplate(): Template {
+		return compileTemplate(
+			this.settings.noteTemplateExternalPDFs,
+			this.templateSettings
+		);
+	}
+
+	get noteFromInternalPDFsTemplate(): Template {
+		return compileTemplate(
+			this.settings.noteTemplateInternalPDFs,
+			this.templateSettings
+		);
+	}
+
+	get highlightFromExternalPDFsTemplate(): Template {
+		return compileTemplate(
+			this.settings.highlightTemplateExternalPDFs,
+			this.templateSettings
+		);
+	}
+
+	get highlightFromInternalPDFsTemplate(): Template {
+		return compileTemplate(
+			this.settings.highlightTemplateInternalPDFs,
+			this.templateSettings
+		);
+	}
+
+	getTemplateVariablesForAnnotation(annotation: any): Record<string, any> {
+		const shortcuts = {
+			highlightedText: annotation.highlightedText,
+			folder: annotation.folder,
+			file: annotation.file,
+			filepath: annotation.filepath,
+			pageNumber: annotation.pageNumber,
+			author: annotation.author,
+			body: annotation.body,
+		};
+
+		return { annotation: annotation, ...shortcuts };
+	}
+
+	getContentForNoteFromExternalPDF(annotation: any): string {
+		return this.noteFromExternalPDFsTemplate(
+			this.getTemplateVariablesForAnnotation(annotation)
+		);
+	}
+
+	getContentForNoteFromInternalPDF(annotation: any): string {
+		return this.noteFromInternalPDFsTemplate(
+			this.getTemplateVariablesForAnnotation(annotation)
+		);
+	}
+
+	getContentForHighlightFromExternalPDF(annotation: any): string {
+		return this.highlightFromExternalPDFsTemplate(
+			this.getTemplateVariablesForAnnotation(annotation)
+		);
+	}
+
+	getContentForHighlightFromInternalPDF(annotation: any): string {
+		return this.highlightFromInternalPDFsTemplate(
+			this.getTemplateVariablesForAnnotation(annotation)
+		);
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -287,6 +287,7 @@ export default class PDFAnnotationPlugin extends Plugin {
 					"highlightTemplateExternalPDFs",
 					"highlightTemplateInternalPDFs",
 					"oneFilePerAnnotation",
+					"oneNotePerAnnotationExportName"
 				];
 				toLoad.forEach((setting) => {
 					if (setting in loadedSettings) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,11 +90,11 @@ export default class PDFAnnotationPlugin extends Plugin {
 		this.sort(grandtotal);
 
 		// Check if one file per annotation should be created
-		if (this.settings.oneFilePerAnnotation) {
+		if (this.settings.oneNotePerAnnotation) {
 			grandtotal.forEach((anno, index) => {
 				const note = this.formatter.format([anno], false);
 				const fileNameOfExportNote =
-					this.getResolvedOneNotePerAnnotationExportName(pdfFile, index) + ".md";
+					this.getResolvedOneNotePerAnnotationExportName(pdfFile, index+1) + ".md";
 				const filePathOfExportNote = this.getResolvedExportPath(pdfFile, fileNameOfExportNote);
 				this.saveHighlightsToFileAndOpenIt(filePathOfExportNote, note);
 			});
@@ -270,7 +270,7 @@ export default class PDFAnnotationPlugin extends Plugin {
 					"noteTemplateInternalPDFs",
 					"highlightTemplateExternalPDFs",
 					"highlightTemplateInternalPDFs",
-					"oneFilePerAnnotation",
+					"oneNotePerAnnotation",
 					"oneNotePerAnnotationExportName"
 				];
 				toLoad.forEach((setting) => {
@@ -332,7 +332,7 @@ export default class PDFAnnotationPlugin extends Plugin {
 	}
 
 	getResolvedOneNotePerAnnotationExportName(file: TFile, counter): string {
-		return this.exportNameTemplate(
+		return this.oneNotePerAnnotationExportNameTemplate(
 			this.getTemplateVariablesForOneNotePerAnnotationExportName(file, counter)
 		);
 	}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -299,9 +299,9 @@ export class PDFAnnotationPluginSettingTab extends PluginSettingTab {
 			)
 			.addText((input) => this.buildValueInput(input, "exportName"));
 		new Setting(containerEl)
-			.setName("One file per annotation")
+			.setName("One note per annotation")
 			.setDesc(
-				"If enabled, every annotation is exported to a separate file."
+				"If enabled, every annotation is exported to a separate note."
 			)
 			.addToggle((toggle) =>
 				toggle

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -310,7 +310,7 @@ export class PDFAnnotationPluginSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.oneNotePerAnnotation)
 					.onChange((value) => {
 						this.plugin.settings.oneNotePerAnnotation = value;
-						oneNotePerAnnotationExportName.settingEl.style.display = value ? "block" : "none";
+						oneNotePerAnnotationExportName.settingEl.style.display = value ? "flex" : "none";
 						this.plugin.saveData(this.plugin.settings);
 					})
 			);
@@ -320,6 +320,6 @@ export class PDFAnnotationPluginSettingTab extends PluginSettingTab {
 				"The name of the notes to which each extracted annotation will be exported. You can use the variable '{{filename}}' to use the PDF's filename and combine it with prefix or suffix. Additionally you should use the variable '{{counter}}' to add the index of the exported annotation."
 			)
 			.addText((input) => this.buildValueInput(input, "oneNotePerAnnotationExportName"));
-		oneNotePerAnnotationExportName.settingEl.style.display = this.plugin.settings.oneNotePerAnnotation ? "block" : "none";
+		oneNotePerAnnotationExportName.settingEl.style.display = this.plugin.settings.oneNotePerAnnotation ? "flex" : "none";
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -170,7 +170,9 @@ export class PDFAnnotationPluginSettingTab extends PluginSettingTab {
 				this.buildValueInput(input, "desiredAnnotations");
 			});
 
-		containerEl.createEl("h3", { text: "Template settings" });
+		
+		containerEl.createEl("h3", { text: "Styling settings" });
+		containerEl.createEl("h4", { text: "Template settings" });
 		const templateInstructionsEl = containerEl.createEl("p");
 		templateInstructionsEl.append(
 			createSpan({
@@ -236,7 +238,8 @@ export class PDFAnnotationPluginSettingTab extends PluginSettingTab {
 				input.inputEl.style.height = "10em";
 				this.buildValueInput(input, "highlightTemplateInternalPDFs");
 			});
-
+		
+		containerEl.createEl("h4", { text: "Structure settings" });
 		new Setting(containerEl)
 			.setName("Use structuring headlines")
 			.setDesc(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -44,6 +44,7 @@ export class PDFAnnotationPluginSetting {
 	public highlightTemplateExternalPDFs: string;
 	public highlightTemplateInternalPDFs: string;
 	public oneFilePerAnnotation: boolean;
+	public oneNotePerAnnotationExportName: string;
 	public parsedSettings: {
 		desiredAnnotations: string[];
 	};
@@ -53,7 +54,7 @@ export class PDFAnnotationPluginSetting {
 		this.useFolderNames = true;
 		this.sortByTopic = true;
 		this.exportPath = "";
-		this.exportName = "{{filename}}";
+		this.exportName = "Annotations for {{filename}}";
 		this.desiredAnnotations = "Text, Highlight, Underline";
 		this.noteTemplateExternalPDFs =
 			"{{body}}\n" +
@@ -80,6 +81,7 @@ export class PDFAnnotationPluginSetting {
 			"* *highlighted by {{author}} at page {{pageNumber}} on [[{{filepath}}]]*\n" +
 			"\n";
 		this.oneFilePerAnnotation = false;
+		this.oneNotePerAnnotationExportName = "Annotations for {{filename}}-{{counter}}";
 		this.parsedSettings = {
 			desiredAnnotations: this.parseCommaSeparatedStringToArray(
 				this.desiredAnnotations
@@ -308,8 +310,15 @@ export class PDFAnnotationPluginSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.oneFilePerAnnotation)
 					.onChange((value) => {
 						this.plugin.settings.oneFilePerAnnotation = value;
+						oneNotePerAnnotationExportName.settingEl.style.display = value ? "block" : "none";
 						this.plugin.saveData(this.plugin.settings);
 					})
 			);
+		let oneNotePerAnnotationExportName = new Setting(containerEl)
+			.setName("One note per annotation - export name")
+			.setDesc(
+				"The name of the notes to which each extracted annotation will be exported. You can use the variable '{{filename}}' to use the PDF's filename and combine it with prefix or suffix. Additionally you should use the variable '{{counter}}' to add the index of the exported annotation."
+			)
+			.addText((input) => this.buildValueInput(input, "oneNotePerAnnotationExportName"));
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -314,11 +314,12 @@ export class PDFAnnotationPluginSettingTab extends PluginSettingTab {
 						this.plugin.saveData(this.plugin.settings);
 					})
 			);
-		let oneNotePerAnnotationExportName = new Setting(containerEl)
+		const oneNotePerAnnotationExportName = new Setting(containerEl)
 			.setName("One note per annotation - export name")
 			.setDesc(
 				"The name of the notes to which each extracted annotation will be exported. You can use the variable '{{filename}}' to use the PDF's filename and combine it with prefix or suffix. Additionally you should use the variable '{{counter}}' to add the index of the exported annotation."
 			)
 			.addText((input) => this.buildValueInput(input, "oneNotePerAnnotationExportName"));
+		oneNotePerAnnotationExportName.settingEl.style.display = this.plugin.settings.oneNotePerAnnotation ? "block" : "none";
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -37,12 +37,13 @@ export class PDFAnnotationPluginSetting {
 	public useFolderNames: boolean;
 	public sortByTopic: boolean;
 	public exportPath: string;
-  public exportName: string;
+	public exportName: string;
 	public desiredAnnotations: string;
 	public noteTemplateExternalPDFs: string;
 	public noteTemplateInternalPDFs: string;
 	public highlightTemplateExternalPDFs: string;
 	public highlightTemplateInternalPDFs: string;
+	public oneFilePerAnnotation: boolean;
 	public parsedSettings: {
 		desiredAnnotations: string[];
 	};
@@ -78,6 +79,7 @@ export class PDFAnnotationPluginSetting {
 			"\n" +
 			"* *highlighted by {{author}} at page {{pageNumber}} on [[{{filepath}}]]*\n" +
 			"\n";
+		this.oneFilePerAnnotation = false;
 		this.parsedSettings = {
 			desiredAnnotations: this.parseCommaSeparatedStringToArray(
 				this.desiredAnnotations
@@ -170,7 +172,6 @@ export class PDFAnnotationPluginSettingTab extends PluginSettingTab {
 				this.buildValueInput(input, "desiredAnnotations");
 			});
 
-		
 		containerEl.createEl("h3", { text: "Styling settings" });
 		containerEl.createEl("h4", { text: "Template settings" });
 		const templateInstructionsEl = containerEl.createEl("p");
@@ -238,7 +239,7 @@ export class PDFAnnotationPluginSettingTab extends PluginSettingTab {
 				input.inputEl.style.height = "10em";
 				this.buildValueInput(input, "highlightTemplateInternalPDFs");
 			});
-		
+
 		containerEl.createEl("h4", { text: "Structure settings" });
 		new Setting(containerEl)
 			.setName("Use structuring headlines")
@@ -291,11 +292,24 @@ export class PDFAnnotationPluginSettingTab extends PluginSettingTab {
 				"The path to which the notes, including the extracted annotations, will be exported. The path can be dynamic './' to create a note next to the PDF or it has to be relative to the vault root. Paths must end with a '/'. Leave blank to export to the vault root."
 			)
 			.addText((input) => this.buildValueInput(input, "exportPath"));
-    new Setting(containerEl)
+		new Setting(containerEl)
 			.setName("Notes export name")
 			.setDesc(
 				"The name of the note to which the notes, including the extracted annotations, will be exported. You can use the variable '{{filename}}' to use the PDF's filename and combine it with prefix or suffix. If you don't use the variable all notes will be exported to the same file until you change the name."
 			)
 			.addText((input) => this.buildValueInput(input, "exportName"));
+		new Setting(containerEl)
+			.setName("One file per annotation")
+			.setDesc(
+				"If enabled, every annotation is exported to a separate file."
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.oneFilePerAnnotation)
+					.onChange((value) => {
+						this.plugin.settings.oneFilePerAnnotation = value;
+						this.plugin.saveData(this.plugin.settings);
+					})
+			);
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -43,7 +43,7 @@ export class PDFAnnotationPluginSetting {
 	public noteTemplateInternalPDFs: string;
 	public highlightTemplateExternalPDFs: string;
 	public highlightTemplateInternalPDFs: string;
-	public oneFilePerAnnotation: boolean;
+	public oneNotePerAnnotation: boolean;
 	public oneNotePerAnnotationExportName: string;
 	public parsedSettings: {
 		desiredAnnotations: string[];
@@ -80,7 +80,7 @@ export class PDFAnnotationPluginSetting {
 			"\n" +
 			"* *highlighted by {{author}} at page {{pageNumber}} on [[{{filepath}}]]*\n" +
 			"\n";
-		this.oneFilePerAnnotation = false;
+		this.oneNotePerAnnotation = false;
 		this.oneNotePerAnnotationExportName = "Annotations for {{filename}}-{{counter}}";
 		this.parsedSettings = {
 			desiredAnnotations: this.parseCommaSeparatedStringToArray(
@@ -307,9 +307,9 @@ export class PDFAnnotationPluginSettingTab extends PluginSettingTab {
 			)
 			.addToggle((toggle) =>
 				toggle
-					.setValue(this.plugin.settings.oneFilePerAnnotation)
+					.setValue(this.plugin.settings.oneNotePerAnnotation)
 					.onChange((value) => {
-						this.plugin.settings.oneFilePerAnnotation = value;
+						this.plugin.settings.oneNotePerAnnotation = value;
 						oneNotePerAnnotationExportName.settingEl.style.display = value ? "block" : "none";
 						this.plugin.saveData(this.plugin.settings);
 					})


### PR DESCRIPTION
## Features
- Added option to export one note per annotation.
- You can also specify the naming scheme for these notes with a counter variable.

Related to #36 

## Changes
- Restructure settings
- Restructure and clarify README to focus on new features

## Code changes
- Reformat main and extract formatter into own class