### PR TITLE
43 3 updatable bonus overwritemerge changes into existing md annotation files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -96,7 +96,7 @@ export default class PDFAnnotationPlugin extends Plugin {
 				const fileNameOfExportNote =
 					this.getResolvedOneNotePerAnnotationExportName(pdfFile, index+1) + ".md";
 				const filePathOfExportNote = this.getResolvedExportPath(pdfFile, fileNameOfExportNote);
-				this.saveHighlightsToFileAndOpenIt(filePathOfExportNote, note);
+				this.saveHighlightsToFileAndOpenIt(filePathOfExportNote, note, this.settings.overwriteExistingNote);
 			});
 		} else {
 			const finalMarkdown = this.formatter.format(grandtotal, false);
@@ -108,7 +108,8 @@ export default class PDFAnnotationPlugin extends Plugin {
 			);
 			await this.saveHighlightsToFileAndOpenIt(
 				filePathOfExportNote,
-				finalMarkdown
+				finalMarkdown, 
+				this.settings.overwriteExistingNote
 			);
 		}
 	}
@@ -353,10 +354,15 @@ export default class PDFAnnotationPlugin extends Plugin {
 		return filePathOfExportNote;
 	}
 
-	async saveHighlightsToFileAndOpenIt(filePath: string, mdString: string) {
+	async saveHighlightsToFileAndOpenIt(filePath: string, mdString: string, overwriteExistingNote: boolean) {
 		const fileExists = await this.app.vault.adapter.exists(filePath);
 		if (fileExists) {
-			await this.appendHighlightsToFile(filePath, mdString);
+			if (overwriteExistingNote) {
+				await this.app.vault.adapter.write(filePath, mdString);
+			} else {
+				await this.appendHighlightsToFile(filePath, mdString);
+			}
+			await this.app.workspace.openLinkText(filePath, "", true);
 		} else {
 			try {
 				await this.app.vault.create(filePath, mdString);

--- a/src/main.ts
+++ b/src/main.ts
@@ -271,7 +271,8 @@ export default class PDFAnnotationPlugin extends Plugin {
 					"highlightTemplateExternalPDFs",
 					"highlightTemplateInternalPDFs",
 					"oneNotePerAnnotation",
-					"oneNotePerAnnotationExportName"
+					"oneNotePerAnnotationExportName",
+					"overwriteExistingNotes",
 				];
 				toLoad.forEach((setting) => {
 					if (setting in loadedSettings) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -45,6 +45,7 @@ export class PDFAnnotationPluginSetting {
 	public highlightTemplateInternalPDFs: string;
 	public oneNotePerAnnotation: boolean;
 	public oneNotePerAnnotationExportName: string;
+	public overwriteExistingNote: boolean;
 	public parsedSettings: {
 		desiredAnnotations: string[];
 	};
@@ -82,6 +83,7 @@ export class PDFAnnotationPluginSetting {
 			"\n";
 		this.oneNotePerAnnotation = false;
 		this.oneNotePerAnnotationExportName = "Annotations for {{filename}}-{{counter}}";
+		this.overwriteExistingNote = false;
 		this.parsedSettings = {
 			desiredAnnotations: this.parseCommaSeparatedStringToArray(
 				this.desiredAnnotations
@@ -321,5 +323,18 @@ export class PDFAnnotationPluginSettingTab extends PluginSettingTab {
 			)
 			.addText((input) => this.buildValueInput(input, "oneNotePerAnnotationExportName"));
 		oneNotePerAnnotationExportName.settingEl.style.display = this.plugin.settings.oneNotePerAnnotation ? "flex" : "none";
+		new Setting(containerEl)
+			.setName("Overwrite existing note")
+			.setDesc(
+				"If enabled, the plugin will overwrite the content of an existing note with the same name."
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.overwriteExistingNote)
+					.onChange((value) => {
+						this.plugin.settings.overwriteExistingNote = value;
+						this.plugin.saveData(this.plugin.settings);
+					})
+			);
 	}
 }


### PR DESCRIPTION
This pull request introduces a new feature to the `PDFAnnotationPlugin` that allows users to overwrite existing notes. The main changes include updates to the plugin's settings and modifications to the method handling file saving.

### New Feature: Overwrite Existing Notes

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL99-R99): Updated the `saveHighlightsToFileAndOpenIt` method to accept an `overwriteExistingNote` parameter and handle overwriting or appending content based on this setting. [[1]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL99-R99) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL111-R112) [[3]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL355-R365)
* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL274-R276): Added the `overwriteExistingNotes` setting to the list of settings to be loaded.

### Settings Update

* [`src/settings.ts`](diffhunk://#diff-bb57a3bd912abc3ec2e729cb8a743838487677a5517683d0c8913a3619ac296aR48): Introduced the `overwriteExistingNote` boolean property to the `PDFAnnotationPluginSetting` class. [[1]](diffhunk://#diff-bb57a3bd912abc3ec2e729cb8a743838487677a5517683d0c8913a3619ac296aR48) [[2]](diffhunk://#diff-bb57a3bd912abc3ec2e729cb8a743838487677a5517683d0c8913a3619ac296aR86)
* [`src/settings.ts`](diffhunk://#diff-bb57a3bd912abc3ec2e729cb8a743838487677a5517683d0c8913a3619ac296aR326-R338): Added a new setting toggle for "Overwrite existing note" in the `PDFAnnotationPluginSettingTab` class. This allows users to enable or disable the overwriting feature through the plugin's settings UI.